### PR TITLE
update prometheus dependency

### DIFF
--- a/misc/metrics/Cargo.toml
+++ b/misc/metrics/Cargo.toml
@@ -26,7 +26,7 @@ libp2p-kad = { version = "0.38.0", path = "../../protocols/kad", optional = true
 libp2p-ping = { version = "0.37.0", path = "../../protocols/ping", optional = true }
 libp2p-relay =  { version = "0.10.0", path = "../../protocols/relay", optional = true }
 libp2p-swarm = { version = "0.37.0", path = "../../swarm" }
-prometheus-client = "0.16.0"
+prometheus-client = "0.18.0"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 libp2p-gossipsub =  { version = "0.39.0", path = "../../protocols/gossipsub", optional = true }

--- a/protocols/gossipsub/Cargo.toml
+++ b/protocols/gossipsub/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 wasm-timer = "0.2.5"
 instant = "0.1.11"
 # Metrics dependencies
-prometheus-client = "0.16.0"
+prometheus-client = "0.18.0"
 
 [dev-dependencies]
 async-std = "1.6.3"


### PR DESCRIPTION
version 0.16 uses `owning_ref` which has memory consumption reported by `cargo audit`. upgrading it to v0.18 will get rid of `owning_ref`

I don't know if we require to add changelog entries for our branch?